### PR TITLE
Configuration for CircleCi (#21)

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -27,3 +27,7 @@ jobs:
 
       - store_test_results:
           path: target/failsafe-reports
+
+      - run:
+          name: Uploading coverage reports
+          command: bash <(curl -s https://codecov.io/bash)

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,0 +1,22 @@
+version: 2
+jobs:
+  build:
+    docker:
+      - image: circleci/openjdk:11-jdk-stretch
+    steps:
+      - checkout
+
+      - restore_cache:
+          key: maven-dependencies-{{ checksum "pom.xml" }}
+
+      - run: ./mvnw dependency:go-offline
+
+      - save_cache:
+          paths:
+            - ~/.m2
+          key: maven-dependencies-{{ checksum "pom.xml" }}
+
+      - run: ./mvnw package
+
+      - store_test_results:
+          path: target/surefire-reports

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -10,7 +10,7 @@ jobs:
           key: maven-dependencies-{{ checksum "pom.xml" }}
 
       - run:
-          name: Download dependencies
+          name: Downloading dependencies
           command: ./mvnw dependency:go-offline
 
       - save_cache:
@@ -19,7 +19,7 @@ jobs:
           key: maven-dependencies-{{ checksum "pom.xml" }}
 
       - run:
-          name: Build and test
+          name: Building and testing
           command: ./mvnw verify
 
       - store_test_results:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -16,7 +16,10 @@ jobs:
             - ~/.m2
           key: maven-dependencies-{{ checksum "pom.xml" }}
 
-      - run: ./mvnw package
+      - run: ./mvnw verify
 
       - store_test_results:
           path: target/surefire-reports
+
+      - store_test_results:
+          path: target/failsafe-reports

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -9,14 +9,18 @@ jobs:
       - restore_cache:
           key: maven-dependencies-{{ checksum "pom.xml" }}
 
-      - run: ./mvnw dependency:go-offline
+      - run:
+          name: Download dependencies
+          command: ./mvnw dependency:go-offline
 
       - save_cache:
           paths:
             - ~/.m2
           key: maven-dependencies-{{ checksum "pom.xml" }}
 
-      - run: ./mvnw verify
+      - run:
+          name: Build and test
+          command: ./mvnw verify
 
       - store_test_results:
           path: target/surefire-reports

--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+[![CircleCI](https://circleci.com/gh/ajurasz/library.svg?style=svg)](https://circleci.com/gh/ajurasz/library)
+
 # Table of contents
 
 1. [About](#about)

--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
-[![CircleCI](https://circleci.com/gh/ajurasz/library.svg?style=svg)](https://circleci.com/gh/ajurasz/library)
+[![CircleCI](https://circleci.com/gh/ddd-by-examples/library.svg?style=svg)](https://circleci.com/gh/ddd-by-examples/library)
+[![Code Coverage](https://codecov.io/gh/ddd-by-examples/library/branch/master/graph/badge.svg)](https://codecov.io/gh/ddd-by-examples/library)
 
 # Table of contents
 

--- a/lombok.config
+++ b/lombok.config
@@ -1,0 +1,1 @@
+lombok.addLombokGeneratedAnnotation = true

--- a/pom.xml
+++ b/pom.xml
@@ -192,7 +192,26 @@
                     </execution>
                 </executions>
             </plugin>
-
+            <plugin>
+                <groupId>org.jacoco</groupId>
+                <artifactId>jacoco-maven-plugin</artifactId>
+                <version>0.8.3</version>
+                <executions>
+                    <execution>
+                        <id>prepare-agent</id>
+                        <goals>
+                            <goal>prepare-agent</goal>
+                        </goals>
+                    </execution>
+                    <execution>
+                        <id>report</id>
+                        <phase>prepare-package</phase>
+                        <goals>
+                            <goal>report</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
         </plugins>
     </build>
 

--- a/pom.xml
+++ b/pom.xml
@@ -209,6 +209,34 @@
                             <goal>prepare-agent-integration</goal>
                         </goals>
                     </execution>
+                    <execution>
+                        <id>merge-results</id>
+                        <phase>verify</phase>
+                        <goals>
+                            <goal>merge</goal>
+                        </goals>
+                        <configuration>
+                            <fileSets>
+                                <fileSet>
+                                    <directory>target</directory>
+                                    <includes>
+                                        <include>*.exec</include>
+                                    </includes>
+                                </fileSet>
+                            </fileSets>
+                            <destFile>target/jacoco-all.exec</destFile>
+                        </configuration>
+                    </execution>
+                    <execution>
+                        <id>report</id>
+                        <phase>verify</phase>
+                        <goals>
+                            <goal>report</goal>
+                        </goals>
+                        <configuration>
+                            <dataFile>target/jacoco-all.exec</dataFile>
+                        </configuration>
+                    </execution>
                 </executions>
             </plugin>
         </plugins>

--- a/pom.xml
+++ b/pom.xml
@@ -204,10 +204,9 @@
                         </goals>
                     </execution>
                     <execution>
-                        <id>report</id>
-                        <phase>prepare-package</phase>
+                        <id>prepare-agent-integration</id>
                         <goals>
-                            <goal>report</goal>
+                            <goal>prepare-agent-integration</goal>
                         </goals>
                     </execution>
                 </executions>


### PR DESCRIPTION
With this PR I have added configuration for CircleCi (#21).

List of changes:
-  CircleCI configuration
- addition of `jacoco-maven-plugin` for generating coverage reports
   - the final report is a merge of unit and integration tests reports
- Lombok customization through a configuration file (to ignore code generated by Lombok in coverage report)
- Upload of coverage report to `codecov` service.


I think that member of `ddd-by-examples` organization will have to log in to CircleCi and `follow` this project so that all future commits are verified on CI.

P.S. These status badges links were handmade - I will verify if they are OK when this PR will land on the master branch.