### PR TITLE
Replaced tuples with domain names

### DIFF
--- a/src/integration-test/groovy/io/pillopl/library/lending/patronprofile/infrastructure/FindingPatronProfileInDatabaseIT.groovy
+++ b/src/integration-test/groovy/io/pillopl/library/lending/patronprofile/infrastructure/FindingPatronProfileInDatabaseIT.groovy
@@ -8,6 +8,8 @@ import io.pillopl.library.lending.librarybranch.model.LibraryBranchId
 import io.pillopl.library.lending.patron.model.PatronEvent
 import io.pillopl.library.lending.patron.model.PatronId
 import io.pillopl.library.lending.patron.model.PatronType
+import io.pillopl.library.lending.patronprofile.model.Checkout
+import io.pillopl.library.lending.patronprofile.model.Hold
 import io.pillopl.library.lending.patronprofile.model.PatronProfile
 import io.pillopl.library.lending.patronprofile.model.PatronProfiles
 import org.springframework.beans.factory.annotation.Autowired
@@ -23,7 +25,6 @@ import static io.pillopl.library.catalogue.BookType.Restricted
 import static io.pillopl.library.lending.book.model.BookFixture.anyBookId
 import static io.pillopl.library.lending.librarybranch.model.LibraryBranchFixture.anyBranch
 import static io.pillopl.library.lending.patron.model.PatronFixture.anyPatronId
-import static io.vavr.Tuple.of
 import static java.time.Instant.now
 
 @SpringBootTest(classes = LendingTestContext.class)
@@ -83,14 +84,14 @@ class FindingPatronProfileInDatabaseIT extends Specification {
 
     void thereIsOnlyOneHold(PatronProfile profile) {
         assert profile.holdsView.currentHolds.size() == 1
-        assert profile.holdsView.currentHolds.get(0).equals(of(bookId, TOMORROW))
+        assert profile.holdsView.currentHolds.get(0) == new Hold(bookId, TOMORROW)
         assert profile.currentCheckouts.currentCheckouts.size() == 0
     }
 
     void thereIsOnlyOneCheckout(PatronProfile profile) {
         assert profile.holdsView.currentHolds.size() == 0
         assert profile.currentCheckouts.currentCheckouts.size() == 1
-        assert profile.currentCheckouts.currentCheckouts.get(0).equals(of(bookId, TOMORROW))
+        assert profile.currentCheckouts.currentCheckouts.get(0) == new Checkout(bookId, TOMORROW)
     }
 
     void thereIsZeroHoldsAndZeroCheckouts(PatronProfile profile) {
@@ -99,7 +100,7 @@ class FindingPatronProfileInDatabaseIT extends Specification {
 
     }
 
-	PatronEvent.BookCheckedOut bookCheckedOutTill(Instant till) {
+    PatronEvent.BookCheckedOut bookCheckedOutTill(Instant till) {
         return new PatronEvent.BookCheckedOut(
                 now(),
                 patronId.getPatronId(),

--- a/src/integration-test/groovy/io/pillopl/library/lending/patronprofile/web/PatronProfileControllerIT.java
+++ b/src/integration-test/groovy/io/pillopl/library/lending/patronprofile/web/PatronProfileControllerIT.java
@@ -6,11 +6,7 @@ import io.pillopl.library.lending.book.model.BookFixture;
 import io.pillopl.library.lending.patron.application.hold.CancelingHold;
 import io.pillopl.library.lending.patron.model.PatronFixture;
 import io.pillopl.library.lending.patron.model.PatronId;
-import io.pillopl.library.lending.patronprofile.model.CheckoutsView;
-import io.pillopl.library.lending.patronprofile.model.HoldsView;
-import io.pillopl.library.lending.patronprofile.model.PatronProfile;
-import io.pillopl.library.lending.patronprofile.model.PatronProfiles;
-import io.vavr.Tuple;
+import io.pillopl.library.lending.patronprofile.model.*;
 import io.vavr.control.Try;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -35,9 +31,7 @@ import static org.mockito.BDDMockito.given;
 import static org.springframework.http.HttpHeaders.CONTENT_TYPE;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
-import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.header;
-import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
-import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
 
 @RunWith(SpringRunner.class)
 @WebMvcTest(PatronProfileController.class)
@@ -191,7 +185,7 @@ public class PatronProfileControllerIT {
 
     PatronProfile profiles() {
         return new PatronProfile(
-                new HoldsView(of(Tuple.of(bookId, anyDate))),
-                new CheckoutsView(of(Tuple.of(anotherBook, anotherDate))));
+                new HoldsView(of(new Hold(bookId, anyDate))),
+                new CheckoutsView(of(new Checkout(anotherBook, anotherDate))));
     }
 }

--- a/src/integration-test/groovy/io/pillopl/library/lending/patronprofile/web/PatronProfileControllerIT.java
+++ b/src/integration-test/groovy/io/pillopl/library/lending/patronprofile/web/PatronProfileControllerIT.java
@@ -6,7 +6,12 @@ import io.pillopl.library.lending.book.model.BookFixture;
 import io.pillopl.library.lending.patron.application.hold.CancelingHold;
 import io.pillopl.library.lending.patron.model.PatronFixture;
 import io.pillopl.library.lending.patron.model.PatronId;
-import io.pillopl.library.lending.patronprofile.model.*;
+import io.pillopl.library.lending.patronprofile.model.Checkout;
+import io.pillopl.library.lending.patronprofile.model.CheckoutsView;
+import io.pillopl.library.lending.patronprofile.model.Hold;
+import io.pillopl.library.lending.patronprofile.model.HoldsView;
+import io.pillopl.library.lending.patronprofile.model.PatronProfile;
+import io.pillopl.library.lending.patronprofile.model.PatronProfiles;
 import io.vavr.control.Try;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -31,7 +36,9 @@ import static org.mockito.BDDMockito.given;
 import static org.springframework.http.HttpHeaders.CONTENT_TYPE;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
-import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.header;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 @RunWith(SpringRunner.class)
 @WebMvcTest(PatronProfileController.class)

--- a/src/main/java/io/pillopl/library/lending/dailysheet/infrastructure/SheetsReadModel.java
+++ b/src/main/java/io/pillopl/library/lending/dailysheet/infrastructure/SheetsReadModel.java
@@ -1,9 +1,17 @@
 package io.pillopl.library.lending.dailysheet.infrastructure;
 
 import io.pillopl.library.catalogue.BookId;
-import io.pillopl.library.lending.dailysheet.model.*;
+import io.pillopl.library.lending.dailysheet.model.CheckoutsToOverdueSheet;
+import io.pillopl.library.lending.dailysheet.model.DailySheet;
+import io.pillopl.library.lending.dailysheet.model.ExpiredHold;
+import io.pillopl.library.lending.dailysheet.model.HoldsToExpireSheet;
+import io.pillopl.library.lending.dailysheet.model.OverdueCheckout;
 import io.pillopl.library.lending.librarybranch.model.LibraryBranchId;
-import io.pillopl.library.lending.patron.model.PatronEvent.*;
+import io.pillopl.library.lending.patron.model.PatronEvent.BookCheckedOut;
+import io.pillopl.library.lending.patron.model.PatronEvent.BookHoldCanceled;
+import io.pillopl.library.lending.patron.model.PatronEvent.BookHoldExpired;
+import io.pillopl.library.lending.patron.model.PatronEvent.BookPlacedOnHold;
+import io.pillopl.library.lending.patron.model.PatronEvent.BookReturned;
 import io.pillopl.library.lending.patron.model.PatronId;
 import io.vavr.control.Option;
 import lombok.AllArgsConstructor;

--- a/src/main/java/io/pillopl/library/lending/dailysheet/infrastructure/SheetsReadModel.java
+++ b/src/main/java/io/pillopl/library/lending/dailysheet/infrastructure/SheetsReadModel.java
@@ -1,13 +1,10 @@
 package io.pillopl.library.lending.dailysheet.infrastructure;
 
 import io.pillopl.library.catalogue.BookId;
-import io.pillopl.library.lending.dailysheet.model.CheckoutsToOverdueSheet;
-import io.pillopl.library.lending.dailysheet.model.DailySheet;
-import io.pillopl.library.lending.dailysheet.model.HoldsToExpireSheet;
+import io.pillopl.library.lending.dailysheet.model.*;
 import io.pillopl.library.lending.librarybranch.model.LibraryBranchId;
 import io.pillopl.library.lending.patron.model.PatronEvent.*;
 import io.pillopl.library.lending.patron.model.PatronId;
-import io.vavr.Tuple3;
 import io.vavr.control.Option;
 import lombok.AllArgsConstructor;
 import org.springframework.context.event.EventListener;
@@ -23,7 +20,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.UUID;
 
-import static io.vavr.Tuple.of;
 import static io.vavr.collection.List.ofAll;
 import static java.sql.Timestamp.from;
 import static java.util.stream.Collectors.toList;
@@ -39,7 +35,7 @@ class SheetsReadModel implements DailySheet {
         return new HoldsToExpireSheet(ofAll(
                 findHoldsToExpire()
                         .stream()
-                        .map(this::toExpiredHoldsTuple)
+                        .map(this::toExpiredHold)
                         .collect(toList())));
     }
 
@@ -50,8 +46,8 @@ class SheetsReadModel implements DailySheet {
                 new ColumnMapRowMapper());
     }
 
-    private Tuple3<BookId, PatronId, LibraryBranchId> toExpiredHoldsTuple(Map<String, Object> map) {
-        return of(
+    private ExpiredHold toExpiredHold(Map<String, Object> map) {
+        return new ExpiredHold(
                 new BookId((UUID) map.get("BOOK_ID")),
                 new PatronId((UUID) map.get("HOLD_BY_PATRON_ID")),
                 new LibraryBranchId((UUID) map.get("HOLD_AT_BRANCH")));
@@ -62,7 +58,7 @@ class SheetsReadModel implements DailySheet {
         return new CheckoutsToOverdueSheet(ofAll(
                 findCheckoutsToOverdue()
                         .stream()
-                        .map(this::toOverdueCheckoutsTuple)
+                        .map(this::toOverdueCheckout)
                         .collect(toList())));
     }
 
@@ -73,8 +69,8 @@ class SheetsReadModel implements DailySheet {
                 new ColumnMapRowMapper());
     }
 
-    private Tuple3<BookId, PatronId, LibraryBranchId> toOverdueCheckoutsTuple(Map<String, Object> map) {
-        return of(
+    private OverdueCheckout toOverdueCheckout(Map<String, Object> map) {
+        return new OverdueCheckout(
                 new BookId((UUID) map.get("BOOK_ID")),
                 new PatronId((UUID) map.get("CHECKED_OUT_BY_PATRON_ID")),
                 new LibraryBranchId((UUID) map.get("CHECKED_OUT_AT_BRANCH")));

--- a/src/main/java/io/pillopl/library/lending/dailysheet/model/CheckoutsToOverdueSheet.java
+++ b/src/main/java/io/pillopl/library/lending/dailysheet/model/CheckoutsToOverdueSheet.java
@@ -1,10 +1,6 @@
 package io.pillopl.library.lending.dailysheet.model;
 
-import io.pillopl.library.catalogue.BookId;
-import io.pillopl.library.lending.librarybranch.model.LibraryBranchId;
 import io.pillopl.library.lending.patron.model.PatronEvent.OverdueCheckoutRegistered;
-import io.pillopl.library.lending.patron.model.PatronId;
-import io.vavr.Tuple3;
 import io.vavr.collection.List;
 import io.vavr.collection.Stream;
 import lombok.NonNull;
@@ -14,21 +10,15 @@ import lombok.Value;
 public class CheckoutsToOverdueSheet {
 
     @NonNull
-    List<Tuple3<BookId, PatronId, LibraryBranchId>> checkouts;
+    List<OverdueCheckout> checkouts;
 
     public Stream<OverdueCheckoutRegistered> toStreamOfEvents() {
-        return checkouts
-                .toStream()
-                .map(this::tupleToEvent);
+        return checkouts.toStream()
+                .map(OverdueCheckout::toEvent);
     }
 
     public int count() {
         return checkouts.size();
     }
-
-    private OverdueCheckoutRegistered tupleToEvent(Tuple3<BookId, PatronId, LibraryBranchId> overdueCheckouts) {
-        return OverdueCheckoutRegistered.now(overdueCheckouts._2, overdueCheckouts._1, overdueCheckouts._3);
-    }
-
 
 }

--- a/src/main/java/io/pillopl/library/lending/dailysheet/model/ExpiredHold.java
+++ b/src/main/java/io/pillopl/library/lending/dailysheet/model/ExpiredHold.java
@@ -1,0 +1,18 @@
+package io.pillopl.library.lending.dailysheet.model;
+
+import io.pillopl.library.catalogue.BookId;
+import io.pillopl.library.lending.librarybranch.model.LibraryBranchId;
+import io.pillopl.library.lending.patron.model.PatronEvent.BookHoldExpired;
+import io.pillopl.library.lending.patron.model.PatronId;
+import lombok.Value;
+
+@Value
+public class ExpiredHold {
+    private final BookId heldBook;
+    private final PatronId patron;
+    private final LibraryBranchId library;
+
+    BookHoldExpired toEvent() {
+        return BookHoldExpired.now(this.heldBook, this.patron, this.library);
+    }
+}

--- a/src/main/java/io/pillopl/library/lending/dailysheet/model/HoldsToExpireSheet.java
+++ b/src/main/java/io/pillopl/library/lending/dailysheet/model/HoldsToExpireSheet.java
@@ -1,10 +1,6 @@
 package io.pillopl.library.lending.dailysheet.model;
 
-import io.pillopl.library.catalogue.BookId;
-import io.pillopl.library.lending.librarybranch.model.LibraryBranchId;
 import io.pillopl.library.lending.patron.model.PatronEvent;
-import io.pillopl.library.lending.patron.model.PatronId;
-import io.vavr.Tuple3;
 import io.vavr.collection.List;
 import io.vavr.collection.Stream;
 import lombok.NonNull;
@@ -15,22 +11,17 @@ import org.springframework.context.event.EventListener;
 public class HoldsToExpireSheet {
 
     @NonNull
-    List<Tuple3<BookId, PatronId, LibraryBranchId>> expiredHolds;
+    List<ExpiredHold> expiredHolds;
 
     @EventListener
     public Stream<PatronEvent.BookHoldExpired> toStreamOfEvents() {
         return expiredHolds
                 .toStream()
-                .map(this::tupleToEvent);
+                .map(ExpiredHold::toEvent);
     }
 
     public int count() {
         return expiredHolds.size();
     }
-
-    private PatronEvent.BookHoldExpired tupleToEvent(Tuple3<BookId, PatronId, LibraryBranchId> expiredHold) {
-        return PatronEvent.BookHoldExpired.now(expiredHold._1, expiredHold._2, expiredHold._3);
-    }
-
 
 }

--- a/src/main/java/io/pillopl/library/lending/dailysheet/model/OverdueCheckout.java
+++ b/src/main/java/io/pillopl/library/lending/dailysheet/model/OverdueCheckout.java
@@ -1,0 +1,18 @@
+package io.pillopl.library.lending.dailysheet.model;
+
+import io.pillopl.library.catalogue.BookId;
+import io.pillopl.library.lending.librarybranch.model.LibraryBranchId;
+import io.pillopl.library.lending.patron.model.PatronEvent.OverdueCheckoutRegistered;
+import io.pillopl.library.lending.patron.model.PatronId;
+import lombok.Value;
+
+@Value
+public class OverdueCheckout {
+    private final BookId checkedOutBook;
+    private final PatronId patron;
+    private final LibraryBranchId library;
+
+    OverdueCheckoutRegistered toEvent() {
+        return OverdueCheckoutRegistered.now(this.patron, this.checkedOutBook, this.library);
+    }
+}

--- a/src/main/java/io/pillopl/library/lending/patronprofile/infrastructure/PatronProfileReadModel.java
+++ b/src/main/java/io/pillopl/library/lending/patronprofile/infrastructure/PatronProfileReadModel.java
@@ -2,7 +2,12 @@ package io.pillopl.library.lending.patronprofile.infrastructure;
 
 import io.pillopl.library.catalogue.BookId;
 import io.pillopl.library.lending.patron.model.PatronId;
-import io.pillopl.library.lending.patronprofile.model.*;
+import io.pillopl.library.lending.patronprofile.model.Checkout;
+import io.pillopl.library.lending.patronprofile.model.CheckoutsView;
+import io.pillopl.library.lending.patronprofile.model.Hold;
+import io.pillopl.library.lending.patronprofile.model.HoldsView;
+import io.pillopl.library.lending.patronprofile.model.PatronProfile;
+import io.pillopl.library.lending.patronprofile.model.PatronProfiles;
 import lombok.AllArgsConstructor;
 import org.springframework.jdbc.core.ColumnMapRowMapper;
 import org.springframework.jdbc.core.JdbcTemplate;

--- a/src/main/java/io/pillopl/library/lending/patronprofile/infrastructure/PatronProfileReadModel.java
+++ b/src/main/java/io/pillopl/library/lending/patronprofile/infrastructure/PatronProfileReadModel.java
@@ -2,18 +2,12 @@ package io.pillopl.library.lending.patronprofile.infrastructure;
 
 import io.pillopl.library.catalogue.BookId;
 import io.pillopl.library.lending.patron.model.PatronId;
-import io.pillopl.library.lending.patronprofile.model.CheckoutsView;
-import io.pillopl.library.lending.patronprofile.model.HoldsView;
-import io.pillopl.library.lending.patronprofile.model.PatronProfile;
-import io.pillopl.library.lending.patronprofile.model.PatronProfiles;
-import io.vavr.Tuple;
-import io.vavr.Tuple2;
+import io.pillopl.library.lending.patronprofile.model.*;
 import lombok.AllArgsConstructor;
 import org.springframework.jdbc.core.ColumnMapRowMapper;
 import org.springframework.jdbc.core.JdbcTemplate;
 
 import java.sql.Timestamp;
-import java.time.Instant;
 import java.util.List;
 import java.util.Map;
 import java.util.UUID;
@@ -31,12 +25,12 @@ class PatronProfileReadModel implements PatronProfiles {
         HoldsView holdsView = new HoldsView(
                 ofAll(findCurrentHoldsFor(patronId)
                         .stream()
-                        .map(this::toHoldViewTuple)
+                        .map(this::toHold)
                         .collect(toList())));
         CheckoutsView checkoutsView = new CheckoutsView(
                 ofAll(findCurrentCheckoutsFor(patronId)
                         .stream()
-                        .map(this::toCheckoutsViewTuple)
+                        .map(this::toCheckout)
                         .collect(toList())));
         return new PatronProfile(holdsView, checkoutsView);
     }
@@ -48,8 +42,8 @@ class PatronProfileReadModel implements PatronProfiles {
                 new ColumnMapRowMapper());
     }
 
-    private Tuple2<BookId, Instant> toHoldViewTuple(Map<String, Object> map) {
-        return Tuple.of(new BookId((UUID) map.get("BOOK_ID")),
+    private Hold toHold(Map<String, Object> map) {
+        return new Hold(new BookId((UUID) map.get("BOOK_ID")),
                 ((Timestamp) map.get("HOLD_TILL")).toInstant());
     }
 
@@ -60,8 +54,8 @@ class PatronProfileReadModel implements PatronProfiles {
                 new ColumnMapRowMapper());
     }
 
-    private Tuple2<BookId, Instant> toCheckoutsViewTuple(Map<String, Object> map) {
-        return Tuple.of(new BookId((UUID) map.get("BOOK_ID")),
+    private Checkout toCheckout(Map<String, Object> map) {
+        return new Checkout(new BookId((UUID) map.get("BOOK_ID")),
                 ((Timestamp) map.get("CHECKOUT_TILL")).toInstant());
     }
 }

--- a/src/main/java/io/pillopl/library/lending/patronprofile/model/Checkout.java
+++ b/src/main/java/io/pillopl/library/lending/patronprofile/model/Checkout.java
@@ -1,0 +1,15 @@
+package io.pillopl.library.lending.patronprofile.model;
+
+import io.pillopl.library.catalogue.BookId;
+import lombok.Value;
+
+import java.time.Instant;
+
+@Value
+public class Checkout {
+
+    private final BookId book;
+
+    private final Instant till;
+
+}

--- a/src/main/java/io/pillopl/library/lending/patronprofile/model/CheckoutsView.java
+++ b/src/main/java/io/pillopl/library/lending/patronprofile/model/CheckoutsView.java
@@ -1,17 +1,13 @@
 package io.pillopl.library.lending.patronprofile.model;
 
-import io.pillopl.library.catalogue.BookId;
-import io.vavr.Tuple2;
 import io.vavr.collection.List;
 import lombok.NonNull;
 import lombok.Value;
-
-import java.time.Instant;
 
 @Value
 public class CheckoutsView {
 
     @NonNull
-    List<Tuple2<BookId, Instant>> currentCheckouts;
+    List<Checkout> currentCheckouts;
 
 }

--- a/src/main/java/io/pillopl/library/lending/patronprofile/model/Hold.java
+++ b/src/main/java/io/pillopl/library/lending/patronprofile/model/Hold.java
@@ -1,0 +1,15 @@
+package io.pillopl.library.lending.patronprofile.model;
+
+import io.pillopl.library.catalogue.BookId;
+import lombok.Value;
+
+import java.time.Instant;
+
+@Value
+public class Hold {
+
+    private final BookId book;
+
+    private final Instant till;
+
+}

--- a/src/main/java/io/pillopl/library/lending/patronprofile/model/HoldsView.java
+++ b/src/main/java/io/pillopl/library/lending/patronprofile/model/HoldsView.java
@@ -1,17 +1,13 @@
 package io.pillopl.library.lending.patronprofile.model;
 
-import io.pillopl.library.catalogue.BookId;
-import io.vavr.Tuple2;
 import io.vavr.collection.List;
 import lombok.NonNull;
 import lombok.Value;
-
-import java.time.Instant;
 
 @Value
 public class HoldsView {
 
     @NonNull
-    List<Tuple2<BookId, Instant>> currentHolds;
+    List<Hold> currentHolds;
 
 }

--- a/src/main/java/io/pillopl/library/lending/patronprofile/model/PatronProfile.java
+++ b/src/main/java/io/pillopl/library/lending/patronprofile/model/PatronProfile.java
@@ -1,12 +1,9 @@
 package io.pillopl.library.lending.patronprofile.model;
 
 import io.pillopl.library.catalogue.BookId;
-import io.vavr.Tuple2;
 import io.vavr.control.Option;
 import lombok.NonNull;
 import lombok.Value;
-
-import java.time.Instant;
 
 @Value
 public class PatronProfile {
@@ -14,20 +11,20 @@ public class PatronProfile {
     @NonNull HoldsView holdsView;
     @NonNull CheckoutsView currentCheckouts;
 
-    public Option<Tuple2<BookId, Instant>> findHold(BookId bookId) {
+    public Option<Hold> findHold(BookId bookId) {
         return
                 holdsView
-                .getCurrentHolds()
-                .toStream()
-                .find(hold -> hold._1.equals(bookId));
+                        .getCurrentHolds()
+                        .toStream()
+                        .find(hold -> hold.getBook().equals(bookId));
     }
 
-    public Option<Tuple2<BookId, Instant>> findCheckout(BookId bookId) {
+    public Option<Checkout> findCheckout(BookId bookId) {
         return
                 currentCheckouts
                         .getCurrentCheckouts()
                         .toStream()
-                        .find(hold -> hold._1.equals(bookId));
+                        .find(hold -> hold.getBook().equals(bookId));
     }
 
 

--- a/src/main/java/io/pillopl/library/lending/patronprofile/web/PatronProfileController.java
+++ b/src/main/java/io/pillopl/library/lending/patronprofile/web/PatronProfileController.java
@@ -8,7 +8,6 @@ import io.pillopl.library.lending.patron.application.hold.CancelingHold;
 import io.pillopl.library.lending.patron.model.PatronId;
 import io.pillopl.library.lending.patronprofile.model.PatronProfiles;
 import io.vavr.Predicates;
-import io.vavr.Tuple2;
 import io.vavr.control.Try;
 import lombok.AllArgsConstructor;
 import lombok.Value;
@@ -25,9 +24,7 @@ import java.time.Instant;
 import java.util.List;
 import java.util.UUID;
 
-import static io.vavr.API.$;
-import static io.vavr.API.Case;
-import static io.vavr.API.Match;
+import static io.vavr.API.*;
 import static java.util.stream.Collectors.toList;
 import static org.springframework.hateoas.server.mvc.WebMvcLinkBuilder.*;
 import static org.springframework.http.ResponseEntity.notFound;
@@ -95,20 +92,47 @@ class PatronProfileController {
                 .getOrElse(ResponseEntity.status(500).build());
 
 
-
-
     }
 
-    private EntityModel<Hold> resourceWithLinkToHoldSelf(UUID patronId, Tuple2<BookId, Instant> hold) {
-        return new EntityModel<>(new Hold(hold._1.getBookId(), hold._2), linkTo(methodOn(PatronProfileController.class).findHold(patronId, hold._1.getBookId())).withSelfRel()
-                .andAffordance(afford(methodOn(PatronProfileController.class).cancelHold(patronId, hold._1.getBookId()))));
+    private EntityModel<Hold> resourceWithLinkToHoldSelf(UUID patronId, io.pillopl.library.lending.patronprofile.model.Hold hold) {
+        return new EntityModel<>(
+                new Hold(hold),
+                linkTo(methodOn(PatronProfileController.class).findHold(patronId, hold.getBook().getBookId()))
+                        .withSelfRel()
+                        .andAffordance(afford(methodOn(PatronProfileController.class)
+                                .cancelHold(patronId, hold.getBook().getBookId()))));
     }
 
-    private EntityModel<Checkout> resourceWithLinkToCheckoutSelf(UUID patronId, Tuple2<BookId, Instant> checkout) {
-        return new EntityModel<>(new Checkout(checkout._1.getBookId(), checkout._2), linkTo(methodOn(PatronProfileController.class).findCheckout(patronId, checkout._1.getBookId())).withSelfRel());
+    private EntityModel<Checkout> resourceWithLinkToCheckoutSelf(UUID patronId, io.pillopl.library.lending.patronprofile.model.Checkout checkout) {
+        return new EntityModel<>(
+                new Checkout(checkout),
+                linkTo(methodOn(PatronProfileController.class).findCheckout(patronId, checkout.getBook().getBookId()))
+                        .withSelfRel());
     }
 
+    @Value
+    private class Hold {
 
+        UUID bookId;
+        Instant till;
+
+        private Hold(io.pillopl.library.lending.patronprofile.model.Hold hold) {
+            this.bookId = hold.getBook().getBookId();
+            this.till = hold.getTill();
+        }
+    }
+
+    @Value
+    private class Checkout {
+
+        UUID bookId;
+        Instant till;
+
+        private Checkout(io.pillopl.library.lending.patronprofile.model.Checkout hold) {
+            this.bookId = hold.getBook().getBookId();
+            this.till = hold.getTill();
+        }
+    }
 }
 
 @Value
@@ -126,18 +150,3 @@ class ProfileResource extends RepresentationModel {
 
 }
 
-@Value
-class Hold {
-
-    UUID bookId;
-    Instant till;
-
-}
-
-@Value
-class Checkout {
-
-    UUID bookId;
-    Instant till;
-
-}

--- a/src/main/java/io/pillopl/library/lending/patronprofile/web/PatronProfileController.java
+++ b/src/main/java/io/pillopl/library/lending/patronprofile/web/PatronProfileController.java
@@ -24,9 +24,13 @@ import java.time.Instant;
 import java.util.List;
 import java.util.UUID;
 
-import static io.vavr.API.*;
+import static io.vavr.API.$;
+import static io.vavr.API.Case;
+import static io.vavr.API.Match;
 import static java.util.stream.Collectors.toList;
-import static org.springframework.hateoas.server.mvc.WebMvcLinkBuilder.*;
+import static org.springframework.hateoas.server.mvc.WebMvcLinkBuilder.afford;
+import static org.springframework.hateoas.server.mvc.WebMvcLinkBuilder.linkTo;
+import static org.springframework.hateoas.server.mvc.WebMvcLinkBuilder.methodOn;
 import static org.springframework.http.ResponseEntity.notFound;
 import static org.springframework.http.ResponseEntity.ok;
 
@@ -110,29 +114,6 @@ class PatronProfileController {
                         .withSelfRel());
     }
 
-    @Value
-    private class Hold {
-
-        UUID bookId;
-        Instant till;
-
-        private Hold(io.pillopl.library.lending.patronprofile.model.Hold hold) {
-            this.bookId = hold.getBook().getBookId();
-            this.till = hold.getTill();
-        }
-    }
-
-    @Value
-    private class Checkout {
-
-        UUID bookId;
-        Instant till;
-
-        private Checkout(io.pillopl.library.lending.patronprofile.model.Checkout hold) {
-            this.bookId = hold.getBook().getBookId();
-            this.till = hold.getTill();
-        }
-    }
 }
 
 @Value
@@ -150,3 +131,27 @@ class ProfileResource extends RepresentationModel {
 
 }
 
+@Value
+class Hold {
+
+    UUID bookId;
+    Instant till;
+
+    Hold(io.pillopl.library.lending.patronprofile.model.Hold hold) {
+        this.bookId = hold.getBook().getBookId();
+        this.till = hold.getTill();
+    }
+}
+
+@Value
+class Checkout {
+
+    UUID bookId;
+    Instant till;
+
+    Checkout(io.pillopl.library.lending.patronprofile.model.Checkout hold) {
+        this.bookId = hold.getBook().getBookId();
+        this.till = hold.getTill();
+    }
+
+}

--- a/src/test/groovy/io/pillopl/library/lending/dailysheet/model/CheckoutsToOverdueSheetTest.groovy
+++ b/src/test/groovy/io/pillopl/library/lending/dailysheet/model/CheckoutsToOverdueSheetTest.groovy
@@ -4,7 +4,6 @@ import io.pillopl.library.catalogue.BookId
 import io.pillopl.library.lending.librarybranch.model.LibraryBranchId
 import io.pillopl.library.lending.patron.model.PatronEvent
 import io.pillopl.library.lending.patron.model.PatronId
-import io.vavr.Tuple
 import io.vavr.collection.List
 import spock.lang.Specification
 
@@ -45,6 +44,8 @@ class CheckoutsToOverdueSheetTest extends Specification {
     }
 
     private CheckoutsToOverdueSheet sheet(PatronId patronId, PatronId anotherPatronId, BookId bookId, BookId anotherBookId, LibraryBranchId libraryBranchId, LibraryBranchId anotherBranchId) {
-        new CheckoutsToOverdueSheet(List.of(Tuple.of(bookId, patronId, libraryBranchId), Tuple.of(anotherBookId, anotherPatronId, anotherBranchId)))
+        new CheckoutsToOverdueSheet(List.of(
+                new OverdueCheckout(bookId, patronId, libraryBranchId),
+                new OverdueCheckout(anotherBookId, anotherPatronId, anotherBranchId)))
     }
 }

--- a/src/test/groovy/io/pillopl/library/lending/dailysheet/model/HoldsToExpireSheetTest.groovy
+++ b/src/test/groovy/io/pillopl/library/lending/dailysheet/model/HoldsToExpireSheetTest.groovy
@@ -4,7 +4,6 @@ import io.pillopl.library.catalogue.BookId
 import io.pillopl.library.lending.librarybranch.model.LibraryBranchId
 import io.pillopl.library.lending.patron.model.PatronEvent
 import io.pillopl.library.lending.patron.model.PatronId
-import io.vavr.Tuple
 import io.vavr.collection.List
 import spock.lang.Specification
 
@@ -45,6 +44,8 @@ class HoldsToExpireSheetTest extends Specification {
     }
 
     private HoldsToExpireSheet sheet(PatronId patronId, PatronId anotherPatronId, BookId bookId, BookId anotherBookId, LibraryBranchId libraryBranchId, LibraryBranchId anotherBranchId) {
-        new HoldsToExpireSheet(List.of(Tuple.of(bookId, patronId, libraryBranchId), Tuple.of(anotherBookId, anotherPatronId, anotherBranchId)))
+        new HoldsToExpireSheet(List.of(
+                new ExpiredHold(bookId, patronId, libraryBranchId),
+                new ExpiredHold(anotherBookId, anotherPatronId, anotherBranchId)))
     }
 }

--- a/src/test/groovy/io/pillopl/library/lending/patron/application/checkout/RegisteringOverdueCheckoutsTest.groovy
+++ b/src/test/groovy/io/pillopl/library/lending/patron/application/checkout/RegisteringOverdueCheckoutsTest.groovy
@@ -3,9 +3,10 @@ package io.pillopl.library.lending.patron.application.checkout
 import io.pillopl.library.commons.commands.BatchResult
 import io.pillopl.library.lending.dailysheet.model.CheckoutsToOverdueSheet
 import io.pillopl.library.lending.dailysheet.model.DailySheet
+import io.pillopl.library.lending.dailysheet.model.OverdueCheckout
 import io.pillopl.library.lending.patron.model.PatronEvent
-import io.pillopl.library.lending.patron.model.Patrons
 import io.pillopl.library.lending.patron.model.PatronId
+import io.pillopl.library.lending.patron.model.Patrons
 import io.vavr.control.Try
 import spock.lang.Specification
 
@@ -63,8 +64,8 @@ class RegisteringOverdueCheckoutsTest extends Specification {
     CheckoutsToOverdueSheet overdueCheckoutsBy(PatronId patronId, PatronId anotherPatronId) {
         return new CheckoutsToOverdueSheet(
                 of(
-                        io.vavr.Tuple.of(anyBookId(), patronId, anyBranch()),
-                        io.vavr.Tuple.of(anyBookId(), anotherPatronId, anyBranch()),
+                        new OverdueCheckout(anyBookId(), patronId, anyBranch()),
+                        new OverdueCheckout(anyBookId(), anotherPatronId, anyBranch()),
 
                 ))
     }

--- a/src/test/groovy/io/pillopl/library/lending/patron/application/hold/ExpiringHoldsTest.groovy
+++ b/src/test/groovy/io/pillopl/library/lending/patron/application/hold/ExpiringHoldsTest.groovy
@@ -2,10 +2,11 @@ package io.pillopl.library.lending.patron.application.hold
 
 import io.pillopl.library.commons.commands.BatchResult
 import io.pillopl.library.lending.dailysheet.model.DailySheet
+import io.pillopl.library.lending.dailysheet.model.ExpiredHold
 import io.pillopl.library.lending.dailysheet.model.HoldsToExpireSheet
 import io.pillopl.library.lending.patron.model.PatronEvent
-import io.pillopl.library.lending.patron.model.Patrons
 import io.pillopl.library.lending.patron.model.PatronId
+import io.pillopl.library.lending.patron.model.Patrons
 import io.vavr.control.Try
 import spock.lang.Specification
 
@@ -61,9 +62,8 @@ class ExpiringHoldsTest extends Specification {
     HoldsToExpireSheet expiredHoldsBy(PatronId patronId, PatronId anotherPatronId) {
         return new HoldsToExpireSheet(
                 of(
-                        io.vavr.Tuple.of(anyBookId(), patronId, anyBranch()),
-                        io.vavr.Tuple.of(anyBookId(), anotherPatronId, anyBranch())
-
+                        new ExpiredHold(anyBookId(), patronId, anyBranch()),
+                        new ExpiredHold(anyBookId(), anotherPatronId, anyBranch())
                 ))
     }
 


### PR DESCRIPTION
I replaced tuples in domain models with domain types, because tuples are names not included in a ubiquitous language.

In my opinion, tuples should only be used as a business workflow output, when the objects returned can't be grouped together as another business object.

I'd be glad with any comments you'll have regarding the names I chose.