### PR TITLE
[FIX] Hateoas consistency and tests fixes

### DIFF
--- a/src/main/java/io/pillopl/library/lending/patronprofile/web/PatronProfileController.java
+++ b/src/main/java/io/pillopl/library/lending/patronprofile/web/PatronProfileController.java
@@ -53,8 +53,8 @@ class PatronProfileController {
     private final CancelingHold cancelingHold;
 
     @GetMapping("/profiles/{patronId}")
-    ResponseEntity<EntityModel<ProfileResource>> patronProfile(@PathVariable UUID patronId) {
-        return ok(new EntityModel<>(new ProfileResource(patronId)));
+    ResponseEntity<ProfileResource> patronProfile(@PathVariable UUID patronId) {
+        return ok(new ProfileResource(patronId));
     }
 
     @GetMapping("/profiles/{patronId}/holds/")


### PR DESCRIPTION
First of all, thanks @pilloPl for great DDD example in practice 💪 

During the project study, I found that not all tests are passing (which brokes CI). Guilty was double wrapping in HATEOAS compatible classes in `PatronProfileController`.

Actual `patronProfile` endpoint result:
```json
{
  "entity": {
    "_links": {
      "holds": {
        "href": "http://localhost:8080/profiles/d969e595-1bc2-40ec-996c-90c6a396a3bd/holds/"
      },
      "checkouts": {
        "href": "http://localhost:8080/profiles/d969e595-1bc2-40ec-996c-90c6a396a3bd/checkouts/"
      },
      "self": {
        "href": "http://localhost:8080/profiles/d969e595-1bc2-40ec-996c-90c6a396a3bd"
      }
    },
    "patronId": "d969e595-1bc2-40ec-996c-90c6a396a3bd"
  }
}
```

Expected result:
```json
{
  "_links": {
    "holds": {
      "href": "http://localhost:8080/profiles/d969e595-1bc2-40ec-996c-90c6a396a3bd/holds/"
    },
    "checkouts": {
      "href": "http://localhost:8080/profiles/d969e595-1bc2-40ec-996c-90c6a396a3bd/checkouts/"
    },
    "self": {
      "href": "http://localhost:8080/profiles/d969e595-1bc2-40ec-996c-90c6a396a3bd"
    }
  },
  "patronId": "d969e595-1bc2-40ec-996c-90c6a396a3bd"
}
```

Small fix applied 😄 