### PR TITLE
Fix a grammar error

### DIFF
--- a/docs/design-level.md
+++ b/docs/design-level.md
@@ -183,7 +183,7 @@ sourced in the business is low enough for CRUD to be well applicable.
 
 ## Aggregates
 
-What you could see in the above examples is that we did not specified the **aggregates** that would be responsible for
+What you could see in the above examples is that we have not specified the **aggregates** that would be responsible for
 handling commands and emitting events.
 Such approach keeps us away from being steered into a particular solution/language and consequently limited from the very
 beginning. Looking at behaviours and responsibilities first lets us understand the problem better, and thus find


### PR DESCRIPTION
"have not specified" or "did not specify" are valid forms. "did not specified" is not.

Thank you so much for the work you've done on this example project 🍺 