### PR TITLE
Use https for spring mvn repo

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -27,7 +27,7 @@
         <repository>
             <id>repository.spring.milestone</id>
             <name>Spring Milestone Repository</name>
-            <url>http://repo.spring.io/milestone</url>
+            <url>https://repo.spring.io/milestone</url>
         </repository>
     </repositories>
 


### PR DESCRIPTION
This prevents a forbidden error from the spring mvn repo:

Could not transfer metadata org.springframework.hateoas:spring-hateoas:1.0.0.BUILD-SNAPSHOT/maven-metadata.xml from/to  Access denied to: http://repo.spring.io/milestone/org/springframework/hateoas/spring-hateoas/1.0.0.BUILD-SNAPSHOT/maven-metadata.xml , ReasonPhrase:Forbidden.