### PR TITLE
test: fix arch unit test 

### DIFF
--- a/src/test/groovy/io/pillopl/library/ModularArchitectureTest.java
+++ b/src/test/groovy/io/pillopl/library/ModularArchitectureTest.java
@@ -25,7 +25,7 @@ public class ModularArchitectureTest {
     public static final ArchRule commons_should_not_depend_on_catalogue =
             noClasses()
                     .that()
-                    .resideInAPackage("..common..")
+                    .resideInAPackage("..commons..")
                     .should()
                     .dependOnClassesThat()
                     .resideInAPackage("..catalogue..");
@@ -34,7 +34,7 @@ public class ModularArchitectureTest {
     public static final ArchRule commons_should_not_depend_on_lending =
             noClasses()
                     .that()
-                    .resideInAPackage("..common..")
+                    .resideInAPackage("..commons..")
                     .should()
                     .dependOnClassesThat()
                     .resideInAPackage("..lending..");


### PR DESCRIPTION
Due to the type in arch unit test, these tests were not verifying correct dependencies, so you could use classes from `landing` package in `commons` for example without breaking the build.