### PR TITLE
fix building error - add pluginRepository for spring release.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -44,6 +44,11 @@
             <id>spring-libs-snapshot</id>
             <url>https://repo.spring.io/snapshot</url>
         </pluginRepository>
+        <pluginRepository>
+            <id>repository.spring.release</id>
+            <name>Spring GA Repository</name>
+            <url>https://repo.spring.io/plugins-release/</url>
+        </pluginRepository>
     </pluginRepositories>
 
     <dependencies>


### PR DESCRIPTION
To avoid maven build error the pluginRepository had to be added in pom.xml.

Initial error
` Plugin org.springframework.boot:spring-boot-maven-plugin:2.2.0.M6 or one of its dependencies could not be resolved: org.springframework.boot:spring-boot-maven-plugin:jar:2.2.0.M6 was not found in https://repo1.maven.org/mave
n2/ during a previous attempt.` 

