### PR TITLE
Fix spring boot starter parent to 2.2.0.RELEASE (2.2.0.M6 was not available anymore)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-starter-parent</artifactId>
-        <version>2.2.0.M6</version>
+        <version>2.2.0.RELEASE</version>
         <relativePath/> <!-- lookup parent from repository -->
     </parent>
     <groupId>io.pillopl</groupId>


### PR DESCRIPTION
Fix spring boot starter parent to 2.2.0.RELEASE (2.2.0.M6 was not available anymore)

![image](https://github.com/user-attachments/assets/8f52ff35-9e9e-4262-8660-71b2fede1ebd)
